### PR TITLE
Support for Oneof Field in proto and ensure multiple object generated with different values

### DIFF
--- a/src/main/java/io/github/murdos/easyrandom/protobuf/ProtobufMessageRandomizer.java
+++ b/src/main/java/io/github/murdos/easyrandom/protobuf/ProtobufMessageRandomizer.java
@@ -15,6 +15,7 @@
  */
 package io.github.murdos.easyrandom.protobuf;
 
+import com.google.protobuf.Descriptors;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.EnumDescriptor;
 import com.google.protobuf.Descriptors.EnumValueDescriptor;
@@ -39,6 +40,8 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Random;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.google.protobuf.Descriptors.FieldDescriptor.JavaType.*;
 
@@ -48,34 +51,23 @@ import static com.google.protobuf.Descriptors.FieldDescriptor.JavaType.*;
 public class ProtobufMessageRandomizer implements Randomizer<Message> {
 
     private final Class<Message> messageClass;
-    private final Random random;
-    private final IntegerRangeRandomizer collectionSizeRandomizer;
     private final EnumMap<JavaType, BiFunction<FieldDescriptor, Builder, Object>> fieldGenerators;
+    private final EasyRandom easyRandom;
+    private final EasyRandomParameters parameters;
 
     public ProtobufMessageRandomizer(Class<Message> messageClass, EasyRandom easyRandom, EasyRandomParameters parameters) {
         this.messageClass = messageClass;
-        this.random = new Random(parameters.getSeed());
-        this.collectionSizeRandomizer = new IntegerRangeRandomizer(
-            parameters.getCollectionSizeRange().getMin(),
-            parameters.getCollectionSizeRange().getMax(),
-            random.nextLong()
-        );
+        this.easyRandom = easyRandom;
+        this.parameters = parameters;
 
         this.fieldGenerators = new EnumMap<>(JavaType.class);
-        IntegerRandomizer integerRandomizer = new IntegerRandomizer(parameters.getSeed());
-        this.fieldGenerators.put(INT, (field, containingBuilder) -> integerRandomizer.getRandomValue());
-        LongRandomizer longRandomizer = new LongRandomizer(parameters.getSeed());
-        this.fieldGenerators.put(LONG, (field, containingBuilder) -> longRandomizer.getRandomValue());
-        FloatRandomizer floatRandomizer = new FloatRandomizer(parameters.getSeed());
-        this.fieldGenerators.put(FLOAT, (field, containingBuilder) -> floatRandomizer.getRandomValue());
-        DoubleRandomizer doubleRandomizer = new DoubleRandomizer(parameters.getSeed());
-        this.fieldGenerators.put(DOUBLE, (field, containingBuilder) -> doubleRandomizer.getRandomValue());
-        BooleanRandomizer booleanRandomizer = new BooleanRandomizer(parameters.getSeed());
-        this.fieldGenerators.put(BOOLEAN, (field, containingBuilder) -> booleanRandomizer.getRandomValue());
-        StringRandomizer stringRandomizer = new StringRandomizer(parameters.getSeed());
-        this.fieldGenerators.put(STRING, (field, containingBuilder) -> stringRandomizer.getRandomValue());
-        ByteStringRandomizer byteStringRandomizer = new ByteStringRandomizer(parameters.getSeed());
-        this.fieldGenerators.put(BYTE_STRING, (field, containingBuilder) -> byteStringRandomizer.getRandomValue());
+        this.fieldGenerators.put(INT, (field, containingBuilder) -> easyRandom.nextInt());
+        this.fieldGenerators.put(LONG, (field, containingBuilder) -> easyRandom.nextLong());
+        this.fieldGenerators.put(FLOAT, (field, containingBuilder) -> easyRandom.nextFloat());
+        this.fieldGenerators.put(DOUBLE, (field, containingBuilder) -> easyRandom.nextDouble());
+        this.fieldGenerators.put(BOOLEAN, (field, containingBuilder) -> easyRandom.nextBoolean());
+        this.fieldGenerators.put(STRING, (field, containingBuilder) -> new StringRandomizer(easyRandom.nextLong()).getRandomValue());
+        this.fieldGenerators.put(BYTE_STRING, (field, containingBuilder) -> new ByteStringRandomizer(easyRandom.nextLong()).getRandomValue());
         this.fieldGenerators.put(ENUM, (field, containingBuilder) -> getRandomEnumValue(field.getEnumType()));
         this.fieldGenerators.put(MESSAGE, (field, containingBuilder) -> easyRandom.nextObject(
             containingBuilder.newBuilderForField(field).getDefaultInstanceForType().getClass()
@@ -87,11 +79,19 @@ public class ProtobufMessageRandomizer implements Randomizer<Message> {
         Message defaultInstance = instantiateMessage(messageClass);
         Builder builder = defaultInstance.newBuilderForType();
         Descriptor descriptor = builder.getDescriptorForType();
-        for (FieldDescriptor field : descriptor.getFields()) {
+        List<Descriptors.OneofDescriptor> oneofs = descriptor.getOneofs();
+        List<FieldDescriptor> plainFields = descriptor.getFields().stream().filter(field-> field.getContainingOneof() == null).collect(Collectors.toList());
+        for (FieldDescriptor field : plainFields) {
             populateField(field, builder);
+        }
+        for (Descriptors.OneofDescriptor oneofDescriptor : oneofs)
+        {
+            populateOneof(oneofDescriptor,builder);
         }
         return builder.build();
     }
+
+
 
     private static Message instantiateMessage(Class<Message> clazz) {
         try {
@@ -105,17 +105,31 @@ public class ProtobufMessageRandomizer implements Randomizer<Message> {
     private void populateField(FieldDescriptor field, Builder containingBuilder) {
         BiFunction<FieldDescriptor, Builder, Object> generator = this.fieldGenerators.get(field.getJavaType());
         if (field.isRepeated()) {
+            IntegerRangeRandomizer collectionSizeRandomizer = new IntegerRangeRandomizer(
+                    parameters.getCollectionSizeRange().getMin(),
+                    parameters.getCollectionSizeRange().getMax(),
+                    easyRandom.nextLong()
+            );
             for (int i = 0; i < collectionSizeRandomizer.getRandomValue(); i++) {
                 containingBuilder.addRepeatedField(field, generator.apply(field, containingBuilder));
             }
-        } else {
+        }
+        else {
             containingBuilder.setField(field, generator.apply(field, containingBuilder));
         }
     }
 
+    private void populateOneof(Descriptors.OneofDescriptor oneofDescriptor, Builder builder) {
+        int fieldCount = oneofDescriptor.getFieldCount();
+        int oneofCase = easyRandom.nextInt(fieldCount);
+        FieldDescriptor selectedCase = oneofDescriptor.getField(oneofCase);
+        populateField(selectedCase,builder);
+    }
+
     private EnumValueDescriptor getRandomEnumValue(EnumDescriptor enumDescriptor) {
         List<EnumValueDescriptor> values = enumDescriptor.getValues();
-        return values.get(random.nextInt(values.size()));
+        int choice = easyRandom.nextInt(values.size());
+        return values.get(choice);
     }
 
     public String toString() {

--- a/src/main/java/io/github/murdos/easyrandom/protobuf/ProtobufMessageRandomizer.java
+++ b/src/main/java/io/github/murdos/easyrandom/protobuf/ProtobufMessageRandomizer.java
@@ -84,14 +84,11 @@ public class ProtobufMessageRandomizer implements Randomizer<Message> {
         for (FieldDescriptor field : plainFields) {
             populateField(field, builder);
         }
-        for (Descriptors.OneofDescriptor oneofDescriptor : oneofs)
-        {
-            populateOneof(oneofDescriptor,builder);
+        for (Descriptors.OneofDescriptor oneofDescriptor : oneofs) {
+            populateOneof(oneofDescriptor, builder);
         }
         return builder.build();
     }
-
-
 
     private static Message instantiateMessage(Class<Message> clazz) {
         try {
@@ -113,8 +110,7 @@ public class ProtobufMessageRandomizer implements Randomizer<Message> {
             for (int i = 0; i < collectionSizeRandomizer.getRandomValue(); i++) {
                 containingBuilder.addRepeatedField(field, generator.apply(field, containingBuilder));
             }
-        }
-        else {
+        } else {
             containingBuilder.setField(field, generator.apply(field, containingBuilder));
         }
     }

--- a/src/test/java/io/github/murdos/easyrandom/protobuf/Protobuf2MessageGenerationTest.java
+++ b/src/test/java/io/github/murdos/easyrandom/protobuf/Protobuf2MessageGenerationTest.java
@@ -18,8 +18,6 @@ package io.github.murdos.easyrandom.protobuf;
 import com.google.protobuf.StringValue;
 import io.github.murdos.easyrandom.protobuf.testing.proto2.Proto2Enum;
 import io.github.murdos.easyrandom.protobuf.testing.proto2.Proto2Message;
-import io.github.murdos.easyrandom.protobuf.testing.proto3.Proto3Enum;
-import io.github.murdos.easyrandom.protobuf.testing.proto3.Proto3Message;
 import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
 import org.junit.jupiter.api.Test;
@@ -73,6 +71,6 @@ class Protobuf2MessageGenerationTest {
             assertThat(embeddedMessage.getStringField()).isEqualTo("LRHCsQ");
             assertThat(embeddedMessage.getEnumField()).isEqualTo(Proto2Enum.THIRD_VALUE);
         });
-        assertThat(protoInstance.getOneofFieldCase().getNumber()).isNotEqualTo(Proto3Message.OneofFieldCase.ONEOFFIELD_NOT_SET);
+        assertThat(protoInstance.getOneofFieldCase().getNumber()).isNotEqualTo(Proto2Message.OneofFieldCase.ONEOFFIELD_NOT_SET);
     }
 }

--- a/src/test/java/io/github/murdos/easyrandom/protobuf/Protobuf2MessageGenerationTest.java
+++ b/src/test/java/io/github/murdos/easyrandom/protobuf/Protobuf2MessageGenerationTest.java
@@ -18,6 +18,8 @@ package io.github.murdos.easyrandom.protobuf;
 import com.google.protobuf.StringValue;
 import io.github.murdos.easyrandom.protobuf.testing.proto2.Proto2Enum;
 import io.github.murdos.easyrandom.protobuf.testing.proto2.Proto2Message;
+import io.github.murdos.easyrandom.protobuf.testing.proto3.Proto3Enum;
+import io.github.murdos.easyrandom.protobuf.testing.proto3.Proto3Message;
 import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
 import org.junit.jupiter.api.Test;
@@ -36,39 +38,41 @@ class Protobuf2MessageGenerationTest {
         Proto2Message protoInstance = easyRandom.nextObject(Proto2Message.class);
 
         assertThat(protoInstance.getDoubleField()).isEqualTo(0.7231742029971469);
-        assertThat(protoInstance.getFloatField()).isEqualTo(0.72317415f);
-        assertThat(protoInstance.getInt32Field()).isEqualTo(-1188957731);
-        assertThat(protoInstance.getInt64Field()).isEqualTo(-5106534569952410475L);
-        assertThat(protoInstance.getUint32Field()).isEqualTo(1018954901);
-        assertThat(protoInstance.getUint64Field()).isEqualTo(-167885730524958550L);
-        assertThat(protoInstance.getSint32Field()).isEqualTo(-39088943);
-        assertThat(protoInstance.getSint64Field()).isEqualTo(4672433029010564658L);
-        assertThat(protoInstance.getFixed32Field()).isEqualTo(1295249578);
-        assertThat(protoInstance.getFixed64Field()).isEqualTo(-7216359497931550918L);
-        assertThat(protoInstance.getSfixed32Field()).isEqualTo(1087885590);
-        assertThat(protoInstance.getSfixed64Field()).isEqualTo(-3581075550420886390L);
+        assertThat(protoInstance.getFloatField()).isEqualTo(0.99089885f);
+        assertThat(protoInstance.getInt32Field()).isEqualTo(1295249578);
+        assertThat(protoInstance.getInt64Field()).isEqualTo(4672433029010564658L);
+        assertThat(protoInstance.getUint32Field()).isEqualTo(-1680189627);
+        assertThat(protoInstance.getUint64Field()).isEqualTo(4775521195821725379L);
+        assertThat(protoInstance.getSint32Field()).isEqualTo(-1621910390);
+        assertThat(protoInstance.getSint64Field()).isEqualTo(-2298228485105199876L);
+        assertThat(protoInstance.getFixed32Field()).isEqualTo(-1219562352);
+        assertThat(protoInstance.getFixed64Field()).isEqualTo(2992351518418085755L);
+        assertThat(protoInstance.getSfixed32Field()).isEqualTo(-1366603797);
+        assertThat(protoInstance.getSfixed64Field()).isEqualTo(-3758321679654915806L);
         assertThat(protoInstance.getBoolField()).isTrue();
-        assertThat(protoInstance.getStringField()).isEqualTo("eOMtThyhVNLWUZNRcBaQKxI");
+        assertThat(protoInstance.getStringField()).isEqualTo("wSxRIexQAaxVLAiN");
         assertThat(protoInstance.getBytesField().toByteArray()).containsExactly(
-                -35, -15, 33, -71, -107, 4, -68, 60, -47, -116, -85, -3, -86, -16, 51, 77,
-                22, -47, -41, 64, 50, 38, -6, -110, 69, 87, -38, -101, 58, 15, 70, 66
+                53,114,79,60,-14,-35,50,97,116,107,41,53,-39,-28,114,79,-111,
+                98,-14,-11,-97,102,-22,83,-126,104,-108,-59,-97,93,-122,-67
         );
-        assertThat(protoInstance.getEnumField()).isEqualTo(Proto2Enum.FOURTH_VALUE);
+
+        assertThat(protoInstance.getEnumField()).isEqualTo(Proto2Enum.THIRD_VALUE);
         assertThat(protoInstance.getStringValueField())
                 .isNotNull()
-                .extracting(StringValue::getValue).isEqualTo("eOMtThyhVNLWUZNRcBaQKxI");
+                .extracting(StringValue::getValue).isEqualTo("tg");
         assertThat(protoInstance.getRepeatedStringFieldList()).containsExactly(
-                "yedUsFwdkelQbxeTeQOvaScfqIOOmaa",
-                "JxkyvRnL",
-                "RYtGKbgicZaHCBRQDSx",
-                "VLhpfQGTMDYpsBZxvfBoeygjb",
-                "UMaAIKKIkknjWEXJUfPxxQHeWKEJ"
+                "AJVH",
+                "WuGaTPB",
+                "NuGSIFWDPVPqKClkqNpxLIRO",
+                "jukCwoSTgRGMwWnAeflhVmclqMX",
+                "bWyqZZW"
         );
 
         assertThat(protoInstance.hasEmbeddedMessage()).isTrue();
         assertThat(protoInstance.getEmbeddedMessage()).satisfies(embeddedMessage -> {
-            assertThat(embeddedMessage.getStringField()).isEqualTo("eOMtThyhVNLWUZNRcBaQKxI");
-            assertThat(embeddedMessage.getEnumField()).isEqualTo(Proto2Enum.FOURTH_VALUE);
+            assertThat(embeddedMessage.getStringField()).isEqualTo("LRHCsQ");
+            assertThat(embeddedMessage.getEnumField()).isEqualTo(Proto2Enum.THIRD_VALUE);
         });
+        assertThat(protoInstance.getOneofFieldCase().getNumber()).isNotEqualTo(Proto3Message.OneofFieldCase.ONEOFFIELD_NOT_SET);
     }
 }

--- a/src/test/java/io/github/murdos/easyrandom/protobuf/Protobuf3MessageGenerationTest.java
+++ b/src/test/java/io/github/murdos/easyrandom/protobuf/Protobuf3MessageGenerationTest.java
@@ -57,15 +57,14 @@ class Protobuf3MessageGenerationTest {
             assertThat(embeddedMessage.getStringField()).isNotBlank();
             assertThat(embeddedMessage.getEnumField()).isIn((Object[]) Proto3Enum.values());
         });
+        assertThat(protoInstance.getOneofFieldCase()).isNotEqualTo(Proto3Message.OneofFieldCase.ONEOFFIELD_NOT_SET);
     }
 
     @Test
     void shouldUseCollectionSizeRangeParameters() {
         EasyRandomParameters parameters = new EasyRandomParameters().collectionSizeRange(3, 3);
         EasyRandom easyRandom = new EasyRandom(parameters);
-
         Proto3Message protoInstance = easyRandom.nextObject(Proto3Message.class);
-
         assertThat(protoInstance.getRepeatedStringFieldList()).hasSize(3);
     }
 
@@ -77,42 +76,79 @@ class Protobuf3MessageGenerationTest {
         EasyRandom easyRandom = new EasyRandom(parameters);
 
         Proto3Message protoInstance = easyRandom.nextObject(Proto3Message.class);
-
         assertThat(protoInstance.getDoubleField()).isEqualTo(0.7231742029971469);
-        assertThat(protoInstance.getFloatField()).isEqualTo(0.72317415f);
-        assertThat(protoInstance.getInt32Field()).isEqualTo(-1188957731);
-        assertThat(protoInstance.getInt64Field()).isEqualTo(-5106534569952410475L);
-        assertThat(protoInstance.getUint32Field()).isEqualTo(1018954901);
-        assertThat(protoInstance.getUint64Field()).isEqualTo(-167885730524958550L);
-        assertThat(protoInstance.getSint32Field()).isEqualTo(-39088943);
-        assertThat(protoInstance.getSint64Field()).isEqualTo(4672433029010564658L);
-        assertThat(protoInstance.getFixed32Field()).isEqualTo(1295249578);
-        assertThat(protoInstance.getFixed64Field()).isEqualTo(-7216359497931550918L);
-        assertThat(protoInstance.getSfixed32Field()).isEqualTo(1087885590);
-        assertThat(protoInstance.getSfixed64Field()).isEqualTo(-3581075550420886390L);
+        assertThat(protoInstance.getFloatField()).isEqualTo(0.99089885f);
+        assertThat(protoInstance.getInt32Field()).isEqualTo(1295249578);
+        assertThat(protoInstance.getInt64Field()).isEqualTo(4672433029010564658L);
+        assertThat(protoInstance.getUint32Field()).isEqualTo(-1680189627);
+        assertThat(protoInstance.getUint64Field()).isEqualTo(4775521195821725379L);
+        assertThat(protoInstance.getSint32Field()).isEqualTo(-1621910390);
+        assertThat(protoInstance.getSint64Field()).isEqualTo(-2298228485105199876L);
+        assertThat(protoInstance.getFixed32Field()).isEqualTo(-1219562352);
+        assertThat(protoInstance.getFixed64Field()).isEqualTo(2992351518418085755L);
+        assertThat(protoInstance.getSfixed32Field()).isEqualTo(-1366603797);
+        assertThat(protoInstance.getSfixed64Field()).isEqualTo(-3758321679654915806L);
         assertThat(protoInstance.getBoolField()).isTrue();
-        assertThat(protoInstance.getStringField()).isEqualTo("eOMtThyhVNLWUZNRcBaQKxI");
+        assertThat(protoInstance.getStringField()).isEqualTo("wSxRIexQAaxVLAiN");
         assertThat(protoInstance.getBytesField().toByteArray()).containsExactly(
-                -35, -15, 33, -71, -107, 4, -68, 60, -47, -116, -85, -3, -86, -16, 51, 77,
-                22, -47, -41, 64, 50, 38, -6, -110, 69, 87, -38, -101, 58, 15, 70, 66
+                53,114,79,60,-14,-35,50,97,116,107,41,53,-39,-28,114,79,-111,
+                98,-14,-11,-97,102,-22,83,-126,104,-108,-59,-97,93,-122,-67
         );
+
         assertThat(protoInstance.getEnumField()).isEqualTo(Proto3Enum.SECOND_VALUE);
         assertThat(protoInstance.getStringValueField())
                 .isNotNull()
-                .extracting(StringValue::getValue).isEqualTo("eOMtThyhVNLWUZNRcBaQKxI");
+                .extracting(StringValue::getValue).isEqualTo("tg");
         assertThat(protoInstance.getRepeatedStringFieldList()).containsExactly(
-                "yedUsFwdkelQbxeTeQOvaScfqIOOmaa",
-                "JxkyvRnL",
-                "RYtGKbgicZaHCBRQDSx",
-                "VLhpfQGTMDYpsBZxvfBoeygjb",
-                "UMaAIKKIkknjWEXJUfPxxQHeWKEJ"
+                "AJVH",
+                "WuGaTPB",
+                "NuGSIFWDPVPqKClkqNpxLIRO",
+                "jukCwoSTgRGMwWnAeflhVmclqMX",
+                "bWyqZZW"
         );
 
         assertThat(protoInstance.hasEmbeddedMessage()).isTrue();
         assertThat(protoInstance.getEmbeddedMessage()).satisfies(embeddedMessage -> {
-            assertThat(embeddedMessage.getStringField()).isEqualTo("eOMtThyhVNLWUZNRcBaQKxI");
-            assertThat(embeddedMessage.getEnumField()).isEqualTo(Proto3Enum.SECOND_VALUE);
+            assertThat(embeddedMessage.getStringField()).isEqualTo("LRHCsQ");
+            assertThat(embeddedMessage.getEnumField()).isEqualTo(Proto3Enum.UNKNOWN);
         });
+        assertThat(protoInstance.getOneofFieldCase()).isEqualTo(Proto3Message.OneofFieldCase.THIRDCHOICE);
+    }
+
+    @Test
+    void shouldGenerateDifferentObject() {
+        EasyRandomParameters parameters = new EasyRandomParameters()
+                .seed(123L)
+                .collectionSizeRange(3, 10);
+        EasyRandom easyRandom = new EasyRandom(parameters);
+
+        Proto3Message protoInstance = easyRandom.nextObject(Proto3Message.class);
+        Proto3Message secondInstance = easyRandom.nextObject(Proto3Message.class);
+
+        assertThat(protoInstance.getDoubleField()).isNotEqualTo(secondInstance.getDoubleField());
+        assertThat(protoInstance.getFloatField()).isNotEqualTo(secondInstance.getFloatField());
+        assertThat(protoInstance.getInt32Field()).isNotEqualTo(secondInstance.getInt32Field());
+        assertThat(protoInstance.getInt64Field()).isNotEqualTo(secondInstance.getInt64Field());
+        assertThat(protoInstance.getUint32Field()).isNotEqualTo(secondInstance.getUint32Field());
+        assertThat(protoInstance.getUint64Field()).isNotEqualTo(secondInstance.getUint64Field());
+        assertThat(protoInstance.getSint32Field()).isNotEqualTo(secondInstance.getSint32Field());
+        assertThat(protoInstance.getSint64Field()).isNotEqualTo(secondInstance.getSint64Field());
+        assertThat(protoInstance.getFixed32Field()).isNotEqualTo(secondInstance.getFixed32Field());
+        assertThat(protoInstance.getFixed64Field()).isNotEqualTo(secondInstance.getFixed64Field());
+        assertThat(protoInstance.getSfixed32Field()).isNotEqualTo(secondInstance.getSfixed32Field());
+        assertThat(protoInstance.getSfixed64Field()).isNotEqualTo(secondInstance.getSfixed64Field());
+
+        assertThat(protoInstance.getStringField()).isNotEqualTo(secondInstance.getStringField());
+        assertThat(protoInstance.getBytesField()).isNotEqualTo(secondInstance.getBytesField());
+
+        assertThat(protoInstance.getStringValueField()).isNotEqualTo(secondInstance.getStringValueField());
+        assertThat(protoInstance.getRepeatedStringFieldList()).isNotEqualTo(secondInstance.getRepeatedStringFieldList());
+
+        assertThat(protoInstance.hasEmbeddedMessage()).isTrue();
+        assertThat(protoInstance.getEmbeddedMessage()).satisfies(embeddedMessage -> {
+            assertThat(embeddedMessage.getStringField()).isNotEqualTo(secondInstance.getEmbeddedMessage().getStringField());
+        });
+
     }
 
     @Test

--- a/src/test/java/io/github/murdos/easyrandom/protobuf/Protobuf3MessageGenerationTest.java
+++ b/src/test/java/io/github/murdos/easyrandom/protobuf/Protobuf3MessageGenerationTest.java
@@ -64,7 +64,9 @@ class Protobuf3MessageGenerationTest {
     void shouldUseCollectionSizeRangeParameters() {
         EasyRandomParameters parameters = new EasyRandomParameters().collectionSizeRange(3, 3);
         EasyRandom easyRandom = new EasyRandom(parameters);
+
         Proto3Message protoInstance = easyRandom.nextObject(Proto3Message.class);
+
         assertThat(protoInstance.getRepeatedStringFieldList()).hasSize(3);
     }
 
@@ -76,6 +78,7 @@ class Protobuf3MessageGenerationTest {
         EasyRandom easyRandom = new EasyRandom(parameters);
 
         Proto3Message protoInstance = easyRandom.nextObject(Proto3Message.class);
+
         assertThat(protoInstance.getDoubleField()).isEqualTo(0.7231742029971469);
         assertThat(protoInstance.getFloatField()).isEqualTo(0.99089885f);
         assertThat(protoInstance.getInt32Field()).isEqualTo(1295249578);
@@ -122,33 +125,32 @@ class Protobuf3MessageGenerationTest {
                 .collectionSizeRange(3, 10);
         EasyRandom easyRandom = new EasyRandom(parameters);
 
-        Proto3Message protoInstance = easyRandom.nextObject(Proto3Message.class);
+        Proto3Message firstInstance = easyRandom.nextObject(Proto3Message.class);
         Proto3Message secondInstance = easyRandom.nextObject(Proto3Message.class);
 
-        assertThat(protoInstance.getDoubleField()).isNotEqualTo(secondInstance.getDoubleField());
-        assertThat(protoInstance.getFloatField()).isNotEqualTo(secondInstance.getFloatField());
-        assertThat(protoInstance.getInt32Field()).isNotEqualTo(secondInstance.getInt32Field());
-        assertThat(protoInstance.getInt64Field()).isNotEqualTo(secondInstance.getInt64Field());
-        assertThat(protoInstance.getUint32Field()).isNotEqualTo(secondInstance.getUint32Field());
-        assertThat(protoInstance.getUint64Field()).isNotEqualTo(secondInstance.getUint64Field());
-        assertThat(protoInstance.getSint32Field()).isNotEqualTo(secondInstance.getSint32Field());
-        assertThat(protoInstance.getSint64Field()).isNotEqualTo(secondInstance.getSint64Field());
-        assertThat(protoInstance.getFixed32Field()).isNotEqualTo(secondInstance.getFixed32Field());
-        assertThat(protoInstance.getFixed64Field()).isNotEqualTo(secondInstance.getFixed64Field());
-        assertThat(protoInstance.getSfixed32Field()).isNotEqualTo(secondInstance.getSfixed32Field());
-        assertThat(protoInstance.getSfixed64Field()).isNotEqualTo(secondInstance.getSfixed64Field());
+        assertThat(firstInstance.getDoubleField()).isNotEqualTo(secondInstance.getDoubleField());
+        assertThat(firstInstance.getFloatField()).isNotEqualTo(secondInstance.getFloatField());
+        assertThat(firstInstance.getInt32Field()).isNotEqualTo(secondInstance.getInt32Field());
+        assertThat(firstInstance.getInt64Field()).isNotEqualTo(secondInstance.getInt64Field());
+        assertThat(firstInstance.getUint32Field()).isNotEqualTo(secondInstance.getUint32Field());
+        assertThat(firstInstance.getUint64Field()).isNotEqualTo(secondInstance.getUint64Field());
+        assertThat(firstInstance.getSint32Field()).isNotEqualTo(secondInstance.getSint32Field());
+        assertThat(firstInstance.getSint64Field()).isNotEqualTo(secondInstance.getSint64Field());
+        assertThat(firstInstance.getFixed32Field()).isNotEqualTo(secondInstance.getFixed32Field());
+        assertThat(firstInstance.getFixed64Field()).isNotEqualTo(secondInstance.getFixed64Field());
+        assertThat(firstInstance.getSfixed32Field()).isNotEqualTo(secondInstance.getSfixed32Field());
+        assertThat(firstInstance.getSfixed64Field()).isNotEqualTo(secondInstance.getSfixed64Field());
 
-        assertThat(protoInstance.getStringField()).isNotEqualTo(secondInstance.getStringField());
-        assertThat(protoInstance.getBytesField()).isNotEqualTo(secondInstance.getBytesField());
+        assertThat(firstInstance.getStringField()).isNotEqualTo(secondInstance.getStringField());
+        assertThat(firstInstance.getBytesField()).isNotEqualTo(secondInstance.getBytesField());
 
-        assertThat(protoInstance.getStringValueField()).isNotEqualTo(secondInstance.getStringValueField());
-        assertThat(protoInstance.getRepeatedStringFieldList()).isNotEqualTo(secondInstance.getRepeatedStringFieldList());
+        assertThat(firstInstance.getStringValueField()).isNotEqualTo(secondInstance.getStringValueField());
+        assertThat(firstInstance.getRepeatedStringFieldList()).isNotEqualTo(secondInstance.getRepeatedStringFieldList());
 
-        assertThat(protoInstance.hasEmbeddedMessage()).isTrue();
-        assertThat(protoInstance.getEmbeddedMessage()).satisfies(embeddedMessage -> {
+        assertThat(firstInstance.hasEmbeddedMessage()).isTrue();
+        assertThat(firstInstance.getEmbeddedMessage()).satisfies(embeddedMessage -> {
             assertThat(embeddedMessage.getStringField()).isNotEqualTo(secondInstance.getEmbeddedMessage().getStringField());
         });
-
     }
 
     @Test

--- a/src/test/proto/Proto2Message.proto
+++ b/src/test/proto/Proto2Message.proto
@@ -28,6 +28,13 @@ message Proto2Message {
   required google.protobuf.StringValue stringValueField = 17;
   repeated string repeatedStringField = 18;
   required EmbeddedProto2Message embeddedMessage = 19;
+
+  oneof oneofField {
+    double firstChoice = 30;
+    string secondChoice = 31;
+    Proto2Enum thirdChoice = 32;
+    EmbeddedProto2Message forthChoice = 33;
+  }
 }
 
 enum Proto2Enum {

--- a/src/test/proto/Proto3Message.proto
+++ b/src/test/proto/Proto3Message.proto
@@ -28,6 +28,13 @@ message Proto3Message {
   google.protobuf.StringValue stringValueField = 17;
   repeated string repeatedStringField = 18;
   EmbeddedProto3Message embeddedMessage = 19;
+
+  oneof oneofField {
+    double firstChoice=30;
+    string secondChoice=31;
+    Proto3Enum thirdChoice=32;
+    EmbeddedProto3Message forthChoice=33;
+  }
 }
 
 enum Proto3Enum {

--- a/src/test/proto/Proto3Message.proto
+++ b/src/test/proto/Proto3Message.proto
@@ -30,10 +30,10 @@ message Proto3Message {
   EmbeddedProto3Message embeddedMessage = 19;
 
   oneof oneofField {
-    double firstChoice=30;
-    string secondChoice=31;
-    Proto3Enum thirdChoice=32;
-    EmbeddedProto3Message forthChoice=33;
+    double firstChoice = 30;
+    string secondChoice = 31;
+    Proto3Enum thirdChoice = 32;
+    EmbeddedProto3Message forthChoice = 33;
   }
 }
 


### PR DESCRIPTION
Added support for OneOf fields in Proto and ensure the library randomly select a value to set.

Also rework the generation of the other fields to ensure when
we generate multiple objects we have different values. Previous implementation
would always generate the same repeated object as the seed doesn't advance
instead was cached at the beginning of the execution. Added unit
test for these and new test verifying we indeed generating different
objects.